### PR TITLE
Adicionada env LEMUR_SKIP_CHECK que se utilizada, permite skipar o lemur.check!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lemur (1.0.0)
+    lemur (1.1.0)
       dotenv (>= 2.7.5)
 
 GEM

--- a/lib/lemur.rb
+++ b/lib/lemur.rb
@@ -15,6 +15,8 @@ module Lemur
     end
 
     def check!
+      return if skip_check?
+
       Lemur::Checker.check!(configuration.key_sets)
     end
 
@@ -24,6 +26,12 @@ module Lemur
 
     def configuration
       @configuration ||= Configuration.new
+    end
+
+    private
+
+    def skip_check?
+      @skip_check ||= ENV.fetch('LEMUR_SKIP_CHECK', false)
     end
   end
 end

--- a/lib/lemur.rb
+++ b/lib/lemur.rb
@@ -31,7 +31,7 @@ module Lemur
     private
 
     def skip_check?
-      @skip_check ||= ENV.fetch('LEMUR_SKIP_CHECK', false)
+      ENV.fetch('LEMUR_SKIP_CHECK', false)
     end
   end
 end

--- a/lib/lemur/version.rb
+++ b/lib/lemur/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lemur
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/lemur/checker_spec.rb
+++ b/spec/lemur/checker_spec.rb
@@ -13,16 +13,7 @@ RSpec.describe Lemur::Checker, type: :model do
     end
 
     context 'without UNKNOWN_ENV' do
-
       it { expect { subject }.to raise_error(Lemur::MissingKeys) }
-      
-      context 'using enviroment LEMUR_SKIP_CHECK' do
-        before { ENV['UNKNOWN_ENV'] = 'development' }
-        before { ENV['LEMUR_SKIP_CHECK'] = 'true' }
-        after { ENV['LEMUR_SKIP_CHECK'] = nil }
-
-        it { expect { subject }.not_to raise_error }
-      end
     end
 
     context 'with UNKNOWN_ENV' do

--- a/spec/lemur/checker_spec.rb
+++ b/spec/lemur/checker_spec.rb
@@ -13,7 +13,16 @@ RSpec.describe Lemur::Checker, type: :model do
     end
 
     context 'without UNKNOWN_ENV' do
+
       it { expect { subject }.to raise_error(Lemur::MissingKeys) }
+      
+      context 'using enviroment LEMUR_SKIP_CHECK' do
+        before { ENV['UNKNOWN_ENV'] = 'development' }
+        before { ENV['LEMUR_SKIP_CHECK'] = 'true' }
+        after { ENV['LEMUR_SKIP_CHECK'] = nil }
+
+        it { expect { subject }.not_to raise_error }
+      end
     end
 
     context 'with UNKNOWN_ENV' do

--- a/spec/lemur_spec.rb
+++ b/spec/lemur_spec.rb
@@ -35,8 +35,21 @@ RSpec.describe Lemur, type: :module do
     let(:keys) { { keys: %w[RAILS_ENV] } }
     let(:clause) { true }
 
-    after { subject }
+    context 'using enviroment LEMUR_SKIP_CHECK' do
+      before { ENV['LEMUR_SKIP_CHECK'] = "true" }
+      after { ENV['LEMUR_SKIP_CHECK'] = nil }
 
-    it { expect(Lemur::Checker).to receive(:check!).once }
+      it do
+        expect(Lemur::Checker).not_to receive(:check!)
+        subject
+      end
+    end
+
+    context 'not using enviroment LEMUR_SKIP_CHECK' do
+      it do
+        expect(Lemur::Checker).to receive(:check!).once
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
* Durante a etapa de build do docker, temos que executar o rake assets:precompile. O problema é que quando executamos, nesse momento ainda não temos disponível no container todas as envs que geralmente estão como required aqui no lemur. Dai como solução podemos skipar a step do lemur no assets(usando LEMUR_SKIP_CHECK=true) e somente rodar o lemur quando de fato for necessário.